### PR TITLE
Namespace ordering

### DIFF
--- a/spring/src/main/java/org/brekka/stillingar/spring/config/ConfigurationServiceBeanDefinitionParser.java
+++ b/spring/src/main/java/org/brekka/stillingar/spring/config/ConfigurationServiceBeanDefinitionParser.java
@@ -36,14 +36,15 @@ import org.brekka.stillingar.spring.bpp.ConfigurationBeanPostProcessor;
 import org.brekka.stillingar.spring.converter.ApplicationContextConverter;
 import org.brekka.stillingar.spring.expr.DefaultPlaceholderParser;
 import org.brekka.stillingar.spring.pc.ConfigurationPlaceholderConfigurer;
+import org.brekka.stillingar.spring.pc.NamespaceConfigurer;
 import org.brekka.stillingar.spring.resource.BasicResourceNameResolver;
 import org.brekka.stillingar.spring.resource.FixedResourceSelector;
 import org.brekka.stillingar.spring.resource.ScanningResourceSelector;
 import org.brekka.stillingar.spring.resource.VersionedResourceNameResolver;
 import org.brekka.stillingar.spring.resource.dir.EnvironmentVariableDirectory;
 import org.brekka.stillingar.spring.resource.dir.HomeDirectory;
-import org.brekka.stillingar.spring.resource.dir.ResourceDirectory;
 import org.brekka.stillingar.spring.resource.dir.PlatformDirectory;
+import org.brekka.stillingar.spring.resource.dir.ResourceDirectory;
 import org.brekka.stillingar.spring.resource.dir.SystemPropertyDirectory;
 import org.brekka.stillingar.spring.resource.dir.WebappDirectory;
 import org.brekka.stillingar.spring.snapshot.ConfigurationSnapshotRefresher;
@@ -169,6 +170,11 @@ class ConfigurationServiceBeanDefinitionParser extends AbstractSingleBeanDefinit
 
             parserContext.registerBeanComponent(new BeanComponentDefinition(placeholderConfigurer.getBeanDefinition(),
                     id + "-placeholderConfigurer"));
+            
+            BeanDefinitionBuilder namespaceConfigurer = BeanDefinitionBuilder
+                    .genericBeanDefinition(NamespaceConfigurer.class);
+            parserContext.registerBeanComponent(new BeanComponentDefinition(namespaceConfigurer.getBeanDefinition(),
+                id + "-namespaceConfigurer"));
         }
     }
 

--- a/spring/src/main/java/org/brekka/stillingar/spring/config/NamespaceBeanDefinitionParser.java
+++ b/spring/src/main/java/org/brekka/stillingar/spring/config/NamespaceBeanDefinitionParser.java
@@ -49,21 +49,7 @@ class NamespaceBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
         }
         String serviceRef = element.getAttribute("service-ref");
         String namespaceContextId = serviceRef + "-Namespaces";
-        try {
-            BeanDefinition namespaceBeanDefinition = parserContext.getRegistry().getBeanDefinition(namespaceContextId);
-            // In the same context, make sure to register the namespace as early as possible.
-            ConstructorArgumentValues constructorArgumentValues = namespaceBeanDefinition.getConstructorArgumentValues();
-            ValueHolder valueHolder = constructorArgumentValues.getIndexedArgumentValue(0, null);
-            Object value = valueHolder.getValue();
-            ManagedArray array = (ManagedArray) value;
-            array.add(prefix);
-            array.add(uri);
-        } catch (NoSuchBeanDefinitionException e) {
-            if (log.isInfoEnabled()) {
-                log.info(String.format("No namespaces context found with id '%s' in the current container", namespaceContextId), e);
-            }
-        }
-        builder.addConstructorArgReference(serviceRef + "-Namespaces");
+        builder.addConstructorArgReference(namespaceContextId);
         builder.addConstructorArgValue(uri);
         builder.addConstructorArgValue(prefix);
     }

--- a/spring/src/main/java/org/brekka/stillingar/spring/config/NamespaceRegisteringBean.java
+++ b/spring/src/main/java/org/brekka/stillingar/spring/config/NamespaceRegisteringBean.java
@@ -35,7 +35,7 @@ import org.springframework.core.Ordered;
  *
  * @author Andrew Taylor (andrew@brekka.org)
  */
-public class NamespaceRegisteringBean implements BeanPostProcessor, Ordered {
+public class NamespaceRegisteringBean {
 
     private static final Log log = LogFactory.getLog(NamespaceRegisteringBean.class);
     
@@ -62,11 +62,7 @@ public class NamespaceRegisteringBean implements BeanPostProcessor, Ordered {
     }
     
 
-    /* (non-Javadoc)
-     * @see org.springframework.beans.factory.config.BeanPostProcessor#postProcessBeforeInitialization(java.lang.Object, java.lang.String)
-     */
-    @Override
-    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+    public void addNamespaceToContext() {
         if (namespaceToPrefixMap != null) {
             Set<Entry<String,String>> entrySet = namespaceToPrefixMap.entrySet();
             for (Entry<String, String> entry : entrySet) {
@@ -77,24 +73,6 @@ public class NamespaceRegisteringBean implements BeanPostProcessor, Ordered {
             }
             namespaceToPrefixMap = null;
         }
-        return bean;
-    }
-
-    /* (non-Javadoc)
-     * @see org.springframework.beans.factory.config.BeanPostProcessor#postProcessAfterInitialization(java.lang.Object, java.lang.String)
-     */
-    @Override
-    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        return bean;
-    }
-    
-    /* (non-Javadoc)
-     * @see org.springframework.core.Ordered#getOrder()
-     */
-    @Override
-    public int getOrder() {
-        // Need to run before ConfigurationBeanPostProcessor
-        return 9;
     }
     
     /**

--- a/spring/src/main/java/org/brekka/stillingar/spring/pc/NamespaceConfigurer.java
+++ b/spring/src/main/java/org/brekka/stillingar/spring/pc/NamespaceConfigurer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.brekka.stillingar.spring.pc;
+
+
+import java.util.Map;
+
+import org.brekka.stillingar.spring.config.NamespaceRegisteringBean;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.Ordered;
+
+/**
+ * Adds namespaces to the configuration but will do so after all the beans have been loaded so that the list
+ * cannot be overriden by multiple stil:configuration-service being added to the context
+ * 
+ * @author Anthony Mayfield
+ */
+public class NamespaceConfigurer implements BeanFactoryPostProcessor, ApplicationContextAware, Ordered {
+
+    /**
+     * The application context that loaded this instance
+     */
+    private ApplicationContext applicationContext;
+
+    /**
+     * The name of this bean within the container.
+     */
+    private String beanName;
+
+    public NamespaceConfigurer() {
+    }
+    
+    @Override
+    public int getOrder() {
+        return 1;
+    }
+
+    /**
+     * This pulls out the list of {@link NamepsaceRegisteringBean} in the context. It then uses this list
+     * to request the namespaces to be added to the context.
+     */
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactoryToProcess) throws BeansException {
+        Map<String,NamespaceRegisteringBean> namespaceRegisteringBeans = applicationContext.getBeansOfType(NamespaceRegisteringBean.class, true, false);
+        for(NamespaceRegisteringBean namespaceRegisteringBean : namespaceRegisteringBeans.values()) {
+            namespaceRegisteringBean.addNamespaceToContext();
+        }
+    }
+    
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+}


### PR DESCRIPTION
Modification to namespace registration so that they are added after the beans are loaded, this ensures that duplication definitions of the configuration-service won't override namespaces already added
